### PR TITLE
Update trimCanvas function to remove trailing row

### DIFF
--- a/escapes.js
+++ b/escapes.js
@@ -201,7 +201,7 @@
         },
 
         trimCanvas: function () {
-            var new_height = (this.row + this.scrollback) * 16,
+            var new_height = (this.row + this.scrollback - 1) * 16,
                 image_data = this.context.getImageData(0, 0, 640, new_height);
 
             this.canvas.height = new_height;


### PR DESCRIPTION
I ran into an issue while using this (amazing) library where there would be a blank line at the bottom of my canvas after rendering an ANSI file. In poking around the code, I was able to resolve this by decrementing the row / scrollback by one when calculating `new_height` in `trimCanvas`.